### PR TITLE
ESLintの設定を追加

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,18 +4,32 @@ module.exports = {
     node: true,
   },
   extends: [
-    'plugin:vue/vue3-essential',
     'eslint:recommended',
-    '@vue/typescript/recommended',
+    './eslint-vue-ts-recommended.js',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:vue/vue3-recommended',
     'plugin:prettier/recommended',
   ],
   parserOptions: {
-    ecmaVersion: 2020,
+    parser: '@typescript-eslint/parser',
   },
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-empty': ['error', { allowEmptyCatch: true }],
+    eqeqeq: 'error',
+    'vue/eqeqeq': 'error',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
     'vue/multi-word-component-names': 'off',
+    'vue/block-lang': [
+      'error',
+      {
+        script: { lang: 'ts' },
+        style: { lang: 'scss' },
+      },
+    ],
+    'vue/component-api-style': ['error', ['composition']],
+    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
     'prettier/prettier': [
       'warn',
       {

--- a/eslint-vue-ts-recommended.js
+++ b/eslint-vue-ts-recommended.js
@@ -1,0 +1,20 @@
+/**
+ * plugin:@typescript-eslint/eslint-recommended
+ *
+ * @typescript-eslint/eslint-recommendedはoverridesが['*.ts','*.tsx']になっている
+ * そのため、`.vue`内の`<script lang='ts'>`に適用されない
+ * 適用されるようにするためにoverridesに'*.vue'を追加する
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const typescriptEslintEslintRecommended = require('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended')
+
+module.exports = {
+  ...typescriptEslintEslintRecommended,
+  overrides: typescriptEslintEslintRecommended.overrides.map((override) => {
+    if (override.files.includes('*.ts')) {
+      return { ...override, files: [...override.files, '*.vue'] }
+    }
+    return override
+  }),
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@typescript-eslint/parser": "^5.5.0",
         "@vitejs/plugin-vue": "^1.10.1",
         "@vue/compiler-sfc": "^3.2.23",
-        "@vue/eslint-config-typescript": "^9.1.0",
         "eslint": "^8.4.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -394,24 +393,6 @@
       "version": "6.0.0-beta.20.1",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.20.1.tgz",
       "integrity": "sha512-R2rfiRY+kZugzWh9ZyITaovx+jpU4vgivAEAiz80kvh3yviiTU3CBuGuyWpSwGz9/C7TkSWVM/FtQRGlZ16n8Q=="
-    },
-    "node_modules/@vue/eslint-config-typescript": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-9.1.0.tgz",
-      "integrity": "sha512-j/852/ZYQ5wDvCD3HE2q4uqJwJAceer2FwoEch1nFo+zTOsPrbzbE3cuWIs3kvu5hdFsGTMYwRwjI6fqZKDMxQ==",
-      "dev": true,
-      "dependencies": {
-        "vue-eslint-parser": "^8.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0",
-        "eslint-plugin-vue": "^8.0.1"
-      }
     },
     "node_modules/@vue/reactivity": {
       "version": "3.2.23",
@@ -2658,15 +2639,6 @@
       "version": "6.0.0-beta.20.1",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.20.1.tgz",
       "integrity": "sha512-R2rfiRY+kZugzWh9ZyITaovx+jpU4vgivAEAiz80kvh3yviiTU3CBuGuyWpSwGz9/C7TkSWVM/FtQRGlZ16n8Q=="
-    },
-    "@vue/eslint-config-typescript": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-9.1.0.tgz",
-      "integrity": "sha512-j/852/ZYQ5wDvCD3HE2q4uqJwJAceer2FwoEch1nFo+zTOsPrbzbE3cuWIs3kvu5hdFsGTMYwRwjI6fqZKDMxQ==",
-      "dev": true,
-      "requires": {
-        "vue-eslint-parser": "^8.0.0"
-      }
     },
     "@vue/reactivity": {
       "version": "3.2.23",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@typescript-eslint/parser": "^5.5.0",
     "@vitejs/plugin-vue": "^1.10.1",
     "@vue/compiler-sfc": "^3.2.23",
-    "@vue/eslint-config-typescript": "^9.1.0",
     "eslint": "^8.4.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",


### PR DESCRIPTION
SysAdのプロジェクトとかからいくつかよさげな設定を追加

- 空ブロックの禁止
- `===` を強制
- exprortする関数の戻り値も明示的に指定しなくてもいいように
- `<script lang="ts">` と `<style lang="scss">` を強制
- Composition APIを強制
- template内でコンポーネントを `<HelloWorld>` じゃなくて `<hello-world>` の形式に

あと `npm run lint` が `.vue` で効いてなかったのを修正